### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,13 @@ function _list (str, isOrdered) {
   return $.html();
 }
 
+function numToString(x) {
+  if (typeof x === 'number')
+    return x.toString()
+
+  return x;
+}
+
 function stringify(x) {
   var output = x ? x.toString() : '';
   return output;
@@ -86,6 +93,7 @@ function trim (str) {
 
 
 module.exports = plumb(
+  numToString,
   listOrdered,
   listUnordered,
   stringify,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mocha": "1.9.0"
   },
   "dependencies": {
-    "cheerio": "0.13.1",
+    "cheerio": "^0.20.0",
     "he": "0.1.1",
     "plumb": "0.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "author": "kurttheviking <kurttheviking@outlook.com>",
   "license": "MIT",
   "devDependencies": {
-    "heredoc": "1.1.0",
     "chai": "1.5.0",
-    "mocha": "1.9.0"
+    "heredoc": "1.1.0",
+    "mocha": "^2.4.5"
   },
   "dependencies": {
     "cheerio": "^0.20.0",


### PR DESCRIPTION
Hi. I'm using this in a small project (it's perfect, thanks!) and getting warnings related to some old dependencies. I've patch the essential ones here.

Two funny notes:

I added a num -> string thing since the new cheerio doesn't do anything with  numeric inputs. This allows the relevant test to pass, so h2p won't harm numeric inputs.

The most recent mocha has a deprecated dependancy... so it'll probably need another update soon.
