### PR TITLE
Remove CSS conditional comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,10 @@ function listUnordered (str) {
   return _list(str, false);
 }
 
+function stripCssConditionalComment (str) {
+  return str.replace(/<!--\[if.*?<!\[endif\]-->/g, '');
+}
+
 function stripTags (str) {
   return str.replace(/<[^<]+>/g, '');
 }
@@ -100,6 +104,7 @@ module.exports = plumb(
   listUnordered,
   collapseWhitespace,
   linebreaks,
+  stripCssConditionalComment,
   stripTags,
   decode,
   trim

--- a/test/test.js
+++ b/test/test.js
@@ -120,4 +120,11 @@ describe('html2plaintext', function () {
 
     expect(expected).to.equal(observed);
   });
+  
+  it('remove CSS conditional comments', function() {
+    var expected = '';
+    var observed = h2p('<!--[if !mso]>\nThis is a test\n<![endif]-->');
+
+    expect(expected).to.equal(observed);
+  });
 });


### PR DESCRIPTION
With the current version, when the HTML contains a CSS conditional comment the content of the conditional comment is shown of the resultant plain text, this is an error.
I have fixed the problem for one situation I'm facing right now, I tried to do it as much generic as I could.