### PR TITLE
Prepend \n\n to (some) other block-level elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function linebreaks (str) {
     // Replace <br> with `\n`
     .replace(/<\s*br\b[^<]*>/gi, '\n')
     // Replace <p> and some other block-level elements with `\n\n`
-    .replace(/<\s*(p|h[1-6]|address|blockquote|div)\b[^<]*>/gi, '\n\n')
+    .replace(/<\s*(address|blockquote|div|h[1-6]|p|pre)\b[^<]*>/gi, '\n\n')
 }
 
 function listOrdered (str) {

--- a/index.js
+++ b/index.js
@@ -62,18 +62,12 @@ function collapseWhitespace (val) {
 }
 
 function linebreaks (str) {
-  var output = str.replace(/<\s?(p|br)[^<]*>/gi, function (x, tag) {
-    switch (tag.toLowerCase()) {
-      case 'p':
-        return '\n\n';
-      case 'br':
-        return '\n';
-    }
-
-    return x;
-  });
-
-  return output;
+  // NB: this function turns `<p>Foo</p><p>Bar</p>` to `\n\nFoo</p>\n\nBar</p>`
+  return str
+    // Replace <br> with `\n`
+    .replace(/<\s*br\b[^<]*>/gi, '\n')
+    // Replace <p> and some other block-level elements with `\n\n`
+    .replace(/<\s*(p|h[1-6]|address|blockquote|div)\b[^<]*>/gi, '\n\n')
 }
 
 function listOrdered (str) {

--- a/test/test.js
+++ b/test/test.js
@@ -75,8 +75,8 @@ describe('html2plaintext', function () {
   });
 
   it('inserts 2 linebreaks after (some) other block-level elements', function () {
-    var expected = 'Foo\n\nBar\n\nBaz\n\nQux.';
-    var observed = h2p('<h1>Foo</h1><h2>Bar</h2><blockquote>Baz</blockquote><div>Qux.</div>');
+    var expected = 'Foo\n\nBar\n\nBaz\n\nQux\n\nFred.';
+    var observed = h2p('<h1>Foo</h1><h2>Bar</h2><blockquote>Baz</blockquote><div>Qux</div><pre>Fred.</pre>');
 
     expect(expected).to.equal(observed);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -74,6 +74,13 @@ describe('html2plaintext', function () {
     expect(expected).to.equal(observed);
   });
 
+  it('inserts 2 linebreaks after (some) other block-level elements', function () {
+    var expected = 'Foo\n\nBar\n\nBaz\n\nQux.';
+    var observed = h2p('<h1>Foo</h1><h2>Bar</h2><blockquote>Baz</blockquote><div>Qux.</div>');
+
+    expect(expected).to.equal(observed);
+  });
+
   it('inserts 1 linebreak <br>', function () {
     var expected = 'hello\ngoodbye';
     var observed = h2p('hello<br/>goodbye');


### PR DESCRIPTION
This PR fixes the following problem:

    html2plaintext('<h1>Foo</h1><p>Bar</p>')  // correctly returns 'Foo\n\nBar'
    html2plaintext('<h1>Foo</h1><h2>Bar</h2>')  // returns 'FooBar', should return 'Foo\n\nBar'

The same problem occurs if I replace `h2` with e.g. `div` or `blockquote`. As per https://github.com/kurttheviking/html2plaintext/blob/master/index.js#L65, it seems that only `p` and `br` (and all other elements starting with `p` or `br`, including `pre`, because the regexp lacks `\b`) get special whitespace treatment.

With this PR, I added some common block-level elements that will also be prepended with `\n\n`.